### PR TITLE
Update Makefile

### DIFF
--- a/2006/build/Makefile
+++ b/2006/build/Makefile
@@ -69,7 +69,7 @@ endif
         LIBMANDIR = $(MANSOURCEPATH)3
        FILEMANDIR = $(MANSOURCEPATH)5
 
-                AR = ar clq
+                AR = ar cq
 
 	    XARGS = xargs
 

--- a/2006/src/config/Imake.tmpl
+++ b/2006/src/config/Imake.tmpl
@@ -485,7 +485,7 @@ XCOMM the platform-specific parameters - edit site.def to change
 #if HasLargeTmp || SystemV4
 #define ArCmd ArCmdBase cq
 #else
-#define ArCmd ArCmdBase clq
+#define ArCmd ArCmdBase cq
 #endif
 #endif
 #ifndef ArAddCmd

--- a/2006/src/config/Makefile
+++ b/2006/src/config/Makefile
@@ -69,7 +69,7 @@ endif
         LIBMANDIR = $(MANSOURCEPATH)3
        FILEMANDIR = $(MANSOURCEPATH)5
 
-                AR = ar clq
+                AR = ar cq
 
 	    XARGS = xargs
 


### PR DESCRIPTION
I get this error:

g77 -c -O -fno-automatic -fno-second-underscore -fugly-complex    -I/home/a/a_neuw01/git/cernlib/2006/build/packlib/hbook -I/home/a/a_neuw01/git/cernlib/2006/src/packlib/hbook -I/home/a/a_neuw01/git/cernlib/2006/src/packlib/hbook/code -I/home/a/a_neuw01/git/cernlib/2006/src/include  -DCERNLIB_LINUX -DCERNLIB_UNIX -DCERNLIB_LNX -DCERNLIB_QMGLIBC -DCERNLIB_QMLXIA64   -o archive/hoptpf.o /home/a/a_neuw01/git/cernlib/2006/src/packlib/hbook/code/hoptpf.F
make[3]: Leaving directory `/home/a/a_neuw01/git/cernlib/2006/build/packlib/hbook/code'
make[2]: Leaving directory `/home/a/a_neuw01/git/cernlib/2006/build/packlib/hbook'
rebuild archive library libpacklib.a in /packlib
Mon Feb 26 19:09:49 CET 2024
ar: libdeps specified more than once
make[1]: *** [libpacklib.a] Error 123

This follows https://github.com/afterstep/afterstep/issues/3#issuecomment-817279697 and fixes it.